### PR TITLE
Fix Vercel config for Vite build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
     {
       "src": "package.json",
       "use": "@vercel/static-build",
-      "config": { "distDir": "build" }
+      "config": { "distDir": "dist" }
     }
   ],
   "routes": [


### PR DESCRIPTION
## Summary
- configure `vercel.json` to point to the correct build directory (`dist`)

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68412ec890588332a4076b15549a355a