### PR TITLE
Add admin blog editor route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# HiveXDIGITAL
+
+This project is a digital marketing agency site built with React and Vite.
+
+## Local development
+
+```bash
+npm install
+npm run dev
+```
+
+## Running tests
+
+```bash
+npm test
+```
+
+## Admin blog editor
+
+A simple WYSIWYG editor page is available at `/admin/blog-editor`. It renders the `BlogAdminEditor` component for quick content editing.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import BlogDetail from './pages/BlogDetail';
 import BlogList from './pages/admin/BlogList';
 import AddBlog from './pages/admin/AddBlog';
 import EditBlog from './pages/admin/EditBlog';
+import AdminBlogEditor from './pages/AdminBlogEditor';
 import ScrollToTop from './components/common/ScrollToTop';
 
 function App() {
@@ -30,6 +31,7 @@ function App() {
           <Route path="admin/blogs" element={<BlogList />} />
           <Route path="admin/add-blog" element={<AddBlog />} />
           <Route path="admin/edit-blog/:id" element={<EditBlog />} />
+          <Route path="admin/blog-editor" element={<AdminBlogEditor />} />
         </Route>
       </Routes>
     </>

--- a/src/pages/AdminBlogEditor.tsx
+++ b/src/pages/AdminBlogEditor.tsx
@@ -1,0 +1,5 @@
+import BlogAdminEditor from '../components/blog/BlogAdminEditor';
+
+export default function AdminBlogEditor() {
+  return <BlogAdminEditor />;
+}


### PR DESCRIPTION
## Summary
- add a minimal page that renders `BlogAdminEditor`
- register the `/admin/blog-editor` route
- document the new page in README

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6841314855e48332bbf566b4ed42e7f0