### PR TITLE
Add simple admin login

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -70,8 +70,8 @@ app.delete('/api/blogs/:id', async (req, res) => {
 });
 
 app.post('/api/contact', async (req, res) => {
-  const { name, email, message } = req.body;
-  const lead = new Lead({ name, email, message });
+  const { name, email, phone, service, subject, message } = req.body;
+  const lead = new Lead({ name, email, phone, service, subject, message });
   await lead.save();
   res.status(201).json(lead);
 });

--- a/server/index.js
+++ b/server/index.js
@@ -70,10 +70,15 @@ app.delete('/api/blogs/:id', async (req, res) => {
 });
 
 app.post('/api/contact', async (req, res) => {
-  const { name, email, phone, service, subject, message } = req.body;
-  const lead = new Lead({ name, email, phone, service, subject, message });
-  await lead.save();
-  res.status(201).json(lead);
+  try {
+    const { name, email, phone, service, subject, message } = req.body;
+    const lead = new Lead({ name, email, phone, service, subject, message });
+    await lead.save();
+    res.status(201).json(lead);
+  } catch (err) {
+    console.error('Failed to save contact lead', err);
+    res.status(500).json({ message: 'Failed to save lead' });
+  }
 });
 
 app.get('/api/leads', async (req, res) => {

--- a/server/models/Lead.js
+++ b/server/models/Lead.js
@@ -3,8 +3,11 @@ import mongoose from 'mongoose';
 const LeadSchema = new mongoose.Schema({
   name: String,
   email: String,
+  phone: String,
+  service: String,
+  subject: String,
   message: String,
-  createdAt: { type: Date, default: Date.now }
+  createdAt: { type: Date, default: Date.now },
 });
 
 export default mongoose.model('Lead', LeadSchema);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Contact from './pages/Contact';
 import Blog from './pages/Blog';
 import BlogDetail from './pages/BlogDetail';
 import Leads from './pages/admin/Leads';
+import AdminLogin from './pages/admin/Login';
 import BlogList from './pages/admin/BlogList';
 import AddBlog from './pages/admin/AddBlog';
 import EditBlog from './pages/admin/EditBlog';
@@ -29,6 +30,7 @@ function App() {
           <Route path="contact" element={<Contact />} />
           <Route path="blog" element={<Blog />} />
           <Route path="blog/:slug" element={<BlogDetail />} />
+          <Route path="admin" element={<AdminLogin />} />
           <Route path="admin/blogs" element={<BlogList />} />
           <Route path="admin/add-blog" element={<AddBlog />} />
           <Route path="admin/edit-blog/:id" element={<EditBlog />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import Layout from './components/layout/Layout';
+import AdminLayout from './components/layout/AdminLayout';
 import Home from './pages/Home';
 import About from './pages/About';
 import Services from './pages/Services';
@@ -14,6 +15,7 @@ import BlogList from './pages/admin/BlogList';
 import AddBlog from './pages/admin/AddBlog';
 import EditBlog from './pages/admin/EditBlog';
 import AdminBlogEditor from './pages/AdminBlogEditor';
+import Dashboard from './pages/admin/Dashboard';
 import ScrollToTop from './components/common/ScrollToTop';
 
 function App() {
@@ -30,12 +32,15 @@ function App() {
           <Route path="contact" element={<Contact />} />
           <Route path="blog" element={<Blog />} />
           <Route path="blog/:slug" element={<BlogDetail />} />
-          <Route path="admin" element={<AdminLogin />} />
-          <Route path="admin/blogs" element={<BlogList />} />
-          <Route path="admin/add-blog" element={<AddBlog />} />
-          <Route path="admin/edit-blog/:id" element={<EditBlog />} />
-          <Route path="admin/blog-editor" element={<AdminBlogEditor />} />
-          <Route path="admin/leads" element={<Leads />} />
+        </Route>
+        <Route path="/admin" element={<AdminLayout />}>
+          <Route index element={<AdminLogin />} />
+          <Route path="dashboard" element={<Dashboard />} />
+          <Route path="blogs" element={<BlogList />} />
+          <Route path="add-blog" element={<AddBlog />} />
+          <Route path="edit-blog/:id" element={<EditBlog />} />
+          <Route path="blog-editor" element={<AdminBlogEditor />} />
+          <Route path="leads" element={<Leads />} />
         </Route>
       </Routes>
     </>

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -47,12 +47,12 @@ const ContactForm = () => {
       });
 
       if (!response.ok) {
+        const text = await response.text();
         let message = 'Something went wrong';
         try {
-          const errorData = await response.json();
+          const errorData = JSON.parse(text);
           message = errorData.message || message;
         } catch {
-          const text = await response.text();
           if (text) message = text;
         }
         throw new Error(message);

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -47,8 +47,15 @@ const ContactForm = () => {
       });
 
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || 'Something went wrong');
+        let message = 'Something went wrong';
+        try {
+          const errorData = await response.json();
+          message = errorData.message || message;
+        } catch {
+          const text = await response.text();
+          if (text) message = text;
+        }
+        throw new Error(message);
       }
 
       setIsSubmitted(true);

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -1,0 +1,40 @@
+import { Outlet, Link, useNavigate } from 'react-router-dom';
+import { logout, isLoggedIn } from '../../utils/auth';
+
+export default function AdminLayout() {
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/admin');
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-gray-800 text-white">
+        <div className="container mx-auto flex justify-between items-center p-4">
+          <h1 className="font-bold text-lg">Admin Panel</h1>
+          {isLoggedIn() && (
+            <nav className="flex gap-4">
+              <Link to="/admin/dashboard" className="hover:underline">
+                Dashboard
+              </Link>
+              <Link to="/admin/blogs" className="hover:underline">
+                Blogs
+              </Link>
+              <Link to="/admin/leads" className="hover:underline">
+                Leads
+              </Link>
+              <button onClick={handleLogout} className="hover:underline">
+                Logout
+              </button>
+            </nav>
+          )}
+        </div>
+      </header>
+      <main className="flex-1 container mx-auto py-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -17,15 +17,15 @@ const Footer = () => {
       <div className="container py-16">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12">
           {/* Company Info */}
-          <div>
+          <div className="text-center md:text-left">
             <Link to="/" className="mb-6 inline-block">
-              <img 
-                src="/PNGlogowhitee.png" 
-                alt="Company Logo" 
+              <img
+                src="/PNGlogowhitee.png"
+                alt="Company Logo"
                 className="h-16 w-auto"
               />
             </Link>
-            <div className="flex space-x-4">
+            <div className="flex justify-center md:justify-start space-x-4">
               <a 
                 href="https://www.facebook.com/people/Hivix-Digital-Solution-Pvt-Ltd/61576329844755/" 
                 target="_blank" 
@@ -66,7 +66,7 @@ const Footer = () => {
           </div>
 
           {/* Quick Links */}
-          <div>
+          <div className="text-center md:text-left">
             <h5 className="text-white font-semibold text-lg mb-6">Quick Links</h5>
             <ul className="space-y-3">
               <li>
@@ -108,7 +108,7 @@ const Footer = () => {
           </div>
 
           {/* Services */}
-          <div>
+          <div className="text-center md:text-left">
             <h5 className="text-white font-semibold text-lg mb-6">Our Services</h5>
             <ul className="space-y-3">
               <li>
@@ -145,7 +145,7 @@ const Footer = () => {
           </div>
 
           {/* Contact Info */}
-          <div>
+          <div className="text-center md:text-left">
             <h5 className="text-white font-semibold text-lg mb-6">Contact Us</h5>
             <ul className="space-y-4">
               <li className="flex items-start gap-3">
@@ -170,7 +170,7 @@ const Footer = () => {
 
         <hr className="border-gray-800 my-10" />
         
-        <div className="flex flex-col md:flex-row justify-between items-center">
+        <div className="flex flex-col md:flex-row justify-between items-center text-center gap-4">
           <p>&copy; {currentYear} Hivix Digital. All rights reserved.</p>
           <div className="mt-4 md:mt-0 flex gap-6">
             <Link to="/privacy-policy" className="hover:text-primary-400 transition-colors text-sm">

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -31,8 +31,8 @@ const Navbar = () => {
     <header
       className={`fixed w-full z-50 transition-all duration-300 ${
         isScrolled
-          ? 'bg-white shadow-md py-3'
-          : 'bg-transparent py-5'
+          ? 'bg-white/90 backdrop-blur-md shadow-md py-3'
+          : 'bg-transparent backdrop-blur-md py-5'
       }`}
     >
       <div className="container flex justify-between items-center">
@@ -161,8 +161,8 @@ const Navbar = () => {
 
       {/* Mobile Menu */}
       {isOpen && (
-        <div className="md:hidden fixed inset-0 top-16 bg-white z-40 animate-slide-down">
-          <nav className="container flex flex-col py-8 space-y-6">
+        <div className="md:hidden fixed inset-0 top-16 bg-white z-40 overflow-y-auto text-center animate-slide-down">
+          <nav className="container flex flex-col items-center py-8 space-y-6">
             <NavLink 
               to="/"
               className={({ isActive }) => 
@@ -217,9 +217,9 @@ const Navbar = () => {
             >
               Blog
             </NavLink>
-            <Link 
+            <Link
               to="/contact"
-              className="btn btn-primary mt-4 w-full text-center"
+              className="btn btn-primary mt-4 w-3/4 mx-auto text-center"
               onClick={closeMenu}
             >
               Contact Us

--- a/src/pages/AdminBlogEditor.tsx
+++ b/src/pages/AdminBlogEditor.tsx
@@ -1,5 +1,8 @@
 import BlogAdminEditor from '../components/blog/BlogAdminEditor';
+import { Navigate } from 'react-router-dom';
+import { isLoggedIn } from '../utils/auth';
 
 export default function AdminBlogEditor() {
+  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   return <BlogAdminEditor />;
 }

--- a/src/pages/admin/AddBlog.tsx
+++ b/src/pages/admin/AddBlog.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom';
+import { isLoggedIn } from '../../utils/auth';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import slugify from 'slugify';
 
 export default function AddBlog() {
+  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   const [title, setTitle] = useState('');
   const [metaTitle, setMetaTitle] = useState('');
   const [metaDescription, setMetaDescription] = useState('');

--- a/src/pages/admin/BlogList.tsx
+++ b/src/pages/admin/BlogList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
+import { isLoggedIn } from '../../utils/auth';
 
 type Blog = {
   _id: string;
@@ -9,6 +10,7 @@ type Blog = {
 };
 
 export default function BlogList() {
+  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   const [blogs, setBlogs] = useState<Blog[]>([]);
 
   const load = () =>

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -1,0 +1,12 @@
+import { Navigate } from 'react-router-dom';
+import { isLoggedIn } from '../../utils/auth';
+
+export default function Dashboard() {
+  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <p>Select an option from the navigation to manage content.</p>
+    </div>
+  );
+}

--- a/src/pages/admin/EditBlog.tsx
+++ b/src/pages/admin/EditBlog.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, Navigate } from 'react-router-dom';
+import { isLoggedIn } from '../../utils/auth';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import slugify from 'slugify';
 
 export default function EditBlog() {
+  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   const { id } = useParams();
   const [title, setTitle] = useState('');
   const [metaTitle, setMetaTitle] = useState('');

--- a/src/pages/admin/Leads.tsx
+++ b/src/pages/admin/Leads.tsx
@@ -1,14 +1,20 @@
 import { useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import { isLoggedIn } from '../../utils/auth';
 
 type Lead = {
   _id: string;
   name: string;
   email: string;
+  phone?: string;
+  service?: string;
+  subject?: string;
   message: string;
   createdAt: string;
 };
 
 export default function Leads() {
+  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   const [leads, setLeads] = useState<Lead[]>([]);
 
   useEffect(() => {
@@ -24,6 +30,9 @@ export default function Leads() {
             <tr className="bg-gray-100">
               <th className="p-2">Name</th>
               <th className="p-2">Email</th>
+              <th className="p-2">Phone</th>
+              <th className="p-2">Service</th>
+              <th className="p-2">Subject</th>
               <th className="p-2">Message</th>
               <th className="p-2">Date</th>
             </tr>
@@ -33,6 +42,9 @@ export default function Leads() {
               <tr key={l._id} className="border-t">
                 <td className="p-2">{l.name}</td>
                 <td className="p-2 break-all">{l.email}</td>
+                <td className="p-2">{l.phone}</td>
+                <td className="p-2">{l.service}</td>
+                <td className="p-2">{l.subject}</td>
                 <td className="p-2">{l.message}</td>
                 <td className="p-2">{new Date(l.createdAt).toLocaleDateString()}</td>
               </tr>

--- a/src/pages/admin/Login.tsx
+++ b/src/pages/admin/Login.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { login, isLoggedIn } from '../../utils/auth';
+
+export default function AdminLogin() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  if (isLoggedIn()) {
+    navigate('/admin/leads');
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (login(username, password)) {
+      navigate('/admin/leads');
+    } else {
+      alert('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="container py-16">
+      <h1 className="text-2xl font-bold mb-4">Admin Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm mx-auto">
+        <input
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+          placeholder="Username"
+          className="w-full p-2 border rounded"
+        />
+        <input
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          type="password"
+          placeholder="Password"
+          className="w-full p-2 border rounded"
+        />
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded w-full">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/admin/Login.tsx
+++ b/src/pages/admin/Login.tsx
@@ -8,13 +8,13 @@ export default function AdminLogin() {
   const navigate = useNavigate();
 
   if (isLoggedIn()) {
-    navigate('/admin/leads');
+    navigate('/admin/dashboard');
   }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (login(username, password)) {
-      navigate('/admin/leads');
+      navigate('/admin/dashboard');
     } else {
       alert('Invalid credentials');
     }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,18 @@
+export const ADMIN_USER = 'vivek';
+export const ADMIN_PASS = 'vivek';
+
+export function login(username: string, password: string): boolean {
+  if (username === ADMIN_USER && password === ADMIN_PASS) {
+    localStorage.setItem('adminLoggedIn', 'true');
+    return true;
+  }
+  return false;
+}
+
+export function logout() {
+  localStorage.removeItem('adminLoggedIn');
+}
+
+export function isLoggedIn(): boolean {
+  return localStorage.getItem('adminLoggedIn') === 'true';
+}


### PR DESCRIPTION
## Summary
- create local auth helper and login page
- protect admin pages using auth utility
- register `/admin` route for login screen

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413e0980908332ae5e835d6d025a18