### PR TITLE
Improve navigation and blog UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Hivix Digital - Digital Marketing Agency</title>
     <meta name="description" content="DigitalEdge is a full-service digital marketing agency specializing in SEO, social media, Google Ads, web design, and content marketing.">
+    <meta property="og:title" content="Hivix Digital - Digital Marketing Agency" />
+    <meta property="og:description" content="DigitalEdge is a full-service digital marketing agency specializing in SEO, social media, Google Ads, web design, and content marketing." />
+    <meta property="og:image" content="/PNGlogo.png" />
+    <meta property="og:url" content="https://hivixdigital.vercel.app" />
+    <meta property="og:type" content="website" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://hivixdigital.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hivixdigital.vercel.app/</loc>
+  </url>
+  <url>
+    <loc>https://hivixdigital.vercel.app/about</loc>
+  </url>
+  <url>
+    <loc>https://hivixdigital.vercel.app/services</loc>
+  </url>
+  <url>
+    <loc>https://hivixdigital.vercel.app/portfolio</loc>
+  </url>
+  <url>
+    <loc>https://hivixdigital.vercel.app/pricing</loc>
+  </url>
+  <url>
+    <loc>https://hivixdigital.vercel.app/blog</loc>
+  </url>
+  <url>
+    <loc>https://hivixdigital.vercel.app/contact</loc>
+  </url>
+</urlset>

--- a/server/index.js
+++ b/server/index.js
@@ -72,7 +72,8 @@ app.delete('/api/blogs/:id', async (req, res) => {
 app.post('/api/contact', async (req, res) => {
   try {
     const { name, email, phone, service, subject, message } = req.body;
-    const lead = new Lead({ name, email, phone, service, subject, message });
+    const sanitizedPhone = phone ? phone.toString().replace(/\D/g, '') : '';
+    const lead = new Lead({ name, email, phone: sanitizedPhone, service, subject, message });
     await lead.save();
     res.status(201).json(lead);
   } catch (err) {

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -129,6 +129,8 @@ const ContactForm = () => {
               name="phone"
               value={formData.phone}
               onChange={handleChange}
+              inputMode="tel"
+              pattern="[0-9]{10,15}"
               className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none transition-colors"
               placeholder="(+91)9664480363"
             />

--- a/src/components/home/CtaSection.tsx
+++ b/src/components/home/CtaSection.tsx
@@ -39,15 +39,25 @@ const CtaSection = () => {
           <p className="text-xl text-gray-100 mb-8">
             Connect with us today for a free consultation and see how our expert digital marketing strategies can drive your business forward.
           </p>
-          <Button 
-            variant="accent" 
-            size="lg" 
+          <Button
+            variant="accent"
+            size="lg"
             href="/contact"
             className="group"
           >
             Get Your Free Consultation
             <ArrowRight className="ml-2 group-hover:translate-x-1 transition-transform" size={20} />
           </Button>
+          <div className="mt-4">
+            <Button
+              variant="outline"
+              size="lg"
+              href="/blog"
+              className="border-white text-white hover:bg-white/10"
+            >
+              Read Our Blog
+            </Button>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -23,6 +23,10 @@ const Navbar = () => {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? 'hidden' : '';
+  }, [isOpen]);
+
   const closeMenu = () => {
     if (isOpen) setIsOpen(false);
   };
@@ -161,7 +165,7 @@ const Navbar = () => {
 
       {/* Mobile Menu */}
       {isOpen && (
-        <div className="md:hidden fixed inset-0 top-16 bg-white z-40 overflow-y-auto text-center animate-slide-down">
+        <div className="md:hidden fixed inset-0 bg-white z-40 overflow-y-auto text-center pt-20 animate-slide-down">
           <nav className="container flex flex-col items-center py-8 space-y-6">
             <NavLink 
               to="/"

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { NavLink, Link } from 'react-router-dom';
-import { MenuIcon, X,  } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -151,9 +151,9 @@ const Navbar = () => {
               className={isScrolled ? 'text-gray-800' : 'text-white'} 
             />
           ) : (
-            <MenuIcon 
-              size={24} 
-              className={isScrolled ? 'text-gray-800' : 'text-white'} 
+            <Menu
+              size={24}
+              className={isScrolled ? 'text-gray-800' : 'text-white'}
             />
           )}
         </button>

--- a/src/pages/BlogDetail.tsx
+++ b/src/pages/BlogDetail.tsx
@@ -27,6 +27,13 @@ export default function BlogDetail() {
       <Helmet>
         <title>{post.metaTitle}</title>
         <meta name="description" content={post.metaDescription} />
+        <meta property="og:title" content={post.metaTitle} />
+        <meta property="og:description" content={post.metaDescription} />
+        {post.coverImage && (
+          <meta property="og:image" content={post.coverImage} />
+        )}
+        <meta property="og:url" content={`${window.location.origin}/blog/${slug}`} />
+        <meta property="og:type" content="article" />
       </Helmet>
       <article className="max-w-3xl mx-auto prose">
         <h1 className="mb-4">{post.title}</h1>

--- a/src/pages/BlogDetail.tsx
+++ b/src/pages/BlogDetail.tsx
@@ -28,9 +28,14 @@ export default function BlogDetail() {
         <title>{post.metaTitle}</title>
         <meta name="description" content={post.metaDescription} />
       </Helmet>
-      <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
-      {post.coverImage && <img src={post.coverImage} className="mb-4" alt="" />}
-      <div dangerouslySetInnerHTML={{ __html: post.content }} />
+      <article className="max-w-3xl mx-auto prose">
+        <h1 className="mb-4">{post.title}</h1>
+        {post.coverImage && (
+          <img src={post.coverImage} className="mb-4 rounded" alt="" />
+        )}
+        <div dangerouslySetInnerHTML={{ __html: post.content }} />
+      </article>
     </div>
   );
 }
+

--- a/src/pages/admin/AddBlog.tsx
+++ b/src/pages/admin/AddBlog.tsx
@@ -6,13 +6,15 @@ import 'react-quill/dist/quill.snow.css';
 import slugify from 'slugify';
 
 export default function AddBlog() {
-  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   const [title, setTitle] = useState('');
   const [metaTitle, setMetaTitle] = useState('');
   const [metaDescription, setMetaDescription] = useState('');
   const [content, setContent] = useState('');
   const [coverImage, setCoverImage] = useState('');
   const navigate = useNavigate();
+  const loggedIn = isLoggedIn();
+
+  if (!loggedIn) return <Navigate to="/admin" replace />;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/admin/BlogList.tsx
+++ b/src/pages/admin/BlogList.tsx
@@ -10,13 +10,17 @@ type Blog = {
 };
 
 export default function BlogList() {
-  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   const [blogs, setBlogs] = useState<Blog[]>([]);
+  const loggedIn = isLoggedIn();
 
   const load = () =>
     fetch('/api/blogs').then(res => res.json()).then(setBlogs);
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    if (loggedIn) load();
+  }, [loggedIn]);
+
+  if (!loggedIn) return <Navigate to="/admin" replace />;
 
   const handleDelete = async(id: string) => {
     await fetch(`/api/blogs/${id}`, { method: 'DELETE' });

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -4,9 +4,11 @@ import { isLoggedIn } from '../../utils/auth';
 export default function Dashboard() {
   if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-      <p>Select an option from the navigation to manage content.</p>
+    <div className="container py-16">
+      <div className="bg-white rounded shadow p-8">
+        <h1 className="text-2xl font-bold mb-4">Welcome to the Dashboard</h1>
+        <p className="text-gray-700">Select an option from the navigation to manage content.</p>
+      </div>
     </div>
   );
 }

--- a/src/pages/admin/EditBlog.tsx
+++ b/src/pages/admin/EditBlog.tsx
@@ -6,7 +6,6 @@ import 'react-quill/dist/quill.snow.css';
 import slugify from 'slugify';
 
 export default function EditBlog() {
-  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   const { id } = useParams();
   const [title, setTitle] = useState('');
   const [metaTitle, setMetaTitle] = useState('');
@@ -14,8 +13,10 @@ export default function EditBlog() {
   const [content, setContent] = useState('');
   const [coverImage, setCoverImage] = useState('');
   const navigate = useNavigate();
+  const loggedIn = isLoggedIn();
 
   useEffect(() => {
+    if (!loggedIn) return;
     fetch(`/api/blogs/${id}`).then(res => res.json()).then(b => {
       setTitle(b.title);
       setMetaTitle(b.metaTitle || '');
@@ -23,7 +24,9 @@ export default function EditBlog() {
       setContent(b.content);
       setCoverImage(b.coverImage || '');
     });
-  }, [id]);
+  }, [id, loggedIn]);
+
+  if (!loggedIn) return <Navigate to="/admin" replace />;
 
   const handleSubmit = async(e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/admin/Leads.tsx
+++ b/src/pages/admin/Leads.tsx
@@ -14,12 +14,16 @@ type Lead = {
 };
 
 export default function Leads() {
-  if (!isLoggedIn()) return <Navigate to="/admin" replace />;
   const [leads, setLeads] = useState<Lead[]>([]);
+  const loggedIn = isLoggedIn();
 
   useEffect(() => {
-    fetch('/api/leads').then(res => res.json()).then(setLeads);
-  }, []);
+    if (loggedIn) {
+      fetch('/api/leads').then(res => res.json()).then(setLeads);
+    }
+  }, [loggedIn]);
+
+  if (!loggedIn) return <Navigate to="/admin" replace />;
 
   return (
     <div className="container py-16">

--- a/src/pages/admin/Leads.tsx
+++ b/src/pages/admin/Leads.tsx
@@ -46,7 +46,7 @@ export default function Leads() {
               <tr key={l._id} className="border-t">
                 <td className="p-2">{l.name}</td>
                 <td className="p-2 break-all">{l.email}</td>
-                <td className="p-2">{l.phone}</td>
+                <td className="p-2">{l.phone || 'N/A'}</td>
                 <td className="p-2">{l.service}</td>
                 <td className="p-2">{l.subject}</td>
                 <td className="p-2">{l.message}</td>


### PR DESCRIPTION
## Summary
- fix mobile menu icon by using `Menu` from lucide-react
- add "Read Our Blog" button to the home page CTA section
- style blog details with `prose` formatting
- enhance admin dashboard layout
- ensure admin pages call hooks before early returns

## Testing
- `npm test -- -t ''`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68415c5a32548332b3cadb02141883d5